### PR TITLE
Update TextViewRowFormer.swift

### DIFF
--- a/Former/RowFormers/TextViewRowFormer.swift
+++ b/Former/RowFormers/TextViewRowFormer.swift
@@ -151,7 +151,7 @@ NSObject, UITextViewDelegate {
     private dynamic func textViewDidChange(textView: UITextView) {
         guard let textViewRowFormer = textViewRowFormer else { return }
         if textViewRowFormer.enabled {
-            if UIDevice.currentDevice().systemVersion.compare("8.0.0", options: .NumericSearch) == .OrderedAscending {
+            if UIDevice.currentDevice().systemVersion.compare("8.0.0", options: .NumericSearch) == .OrderedDescending {
                 textView.scrollRangeToVisible(textView.selectedRange)
             }
             let text = textView.text ?? ""


### PR DESCRIPTION
When trying to compare current system version against lowest supported "8.0.0" you should use .OrderedDescending instead of .OrderedAscending, because system version must be higher or equal to the specified one.
