### PR TITLE
Update InlinePickerRowFormer.swift - system version check

### DIFF
--- a/Former/RowFormers/InlinePickerRowFormer.swift
+++ b/Former/RowFormers/InlinePickerRowFormer.swift
@@ -93,7 +93,7 @@ public class InlinePickerRowFormer<T: UITableViewCell, S where T: InlinePickerFo
             $0.pickerItems = pickerItems
             $0.selectedRow = selectedRow
             $0.enabled = enabled
-            if UIDevice.currentDevice().systemVersion.compare("8.0.0", options: .NumericSearch) == .OrderedAscending {
+            if UIDevice.currentDevice().systemVersion.compare("8.0.0", options: .NumericSearch) == .OrderedDescending {
                 $0.cell.pickerView.reloadAllComponents()
             }
         }.onValueChanged(valueChanged).update()


### PR DESCRIPTION
When trying to compare current system version against lowest supported "8.0.0" you should use .OrderedDescending instead of .OrderedAscending, because system version must be higher or equal to the specified one.
