### PR TITLE
Fix tableview editing crash when removing inline row formers

### DIFF
--- a/Former/Commons/Former.swift
+++ b/Former/Commons/Former.swift
@@ -780,9 +780,9 @@ public final class Former: NSObject {
                 if rowFormers.contains(where: { $0 === rowFormer }) {
                     removeIndexPaths.append(IndexPath(row: row, section: section))
                     sectionFormer.remove(rowFormers: [rowFormer])
-                    if let oldInlineRowFormer = (rowFormer as? InlineForm)?.inlineRowFormer {
+                    if let oldInlineRowFormer = (rowFormer as? InlineForm)?.inlineRowFormer,
+                        let removedIndexPath = removeRowFormers([oldInlineRowFormer]).first {
                         removeIndexPaths.append(IndexPath(row: row + 1, section: section))
-                        _ = removeRowFormers([oldInlineRowFormer])
                         (inlineRowFormer as? InlineForm)?.editingDidEnd()
                         inlineRowFormer = nil
                     }


### PR DESCRIPTION
Checking former's type is not enough to determine if we have to remove the next row.
Hence his will produce a crash because the table will try to remove a row from an unexpected index.