### PR TITLE
Setting APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/Former.xcodeproj/project.pbxproj
+++ b/Former.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -418,6 +419,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This allows using Former from frameworks.

<img width="595" alt="screen shot 2017-02-16 at 4 13 11 pm" src="https://cloud.githubusercontent.com/assets/685609/23047147/d4ffac1c-f462-11e6-8133-9daf2ccfd69b.png">