### PR TITLE
Made cellSelected of RowFormer class open instead of public

### DIFF
--- a/Former/Commons/RowFormer.swift
+++ b/Former/Commons/RowFormer.swift
@@ -68,7 +68,7 @@ open class RowFormer {
         }
     }
     
-    public func cellSelected(indexPath: IndexPath) {
+    open func cellSelected(indexPath: IndexPath) {
         if enabled {
             onSelected?(self)
         }

--- a/Former/RowFormers/CheckRowFormer.swift
+++ b/Former/RowFormers/CheckRowFormer.swift
@@ -51,7 +51,7 @@ open class CheckRowFormer<T: UITableViewCell>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         former?.deselect(animated: true)
         if enabled {
             checked = !checked

--- a/Former/RowFormers/InlineDatePickerRowFormer.swift
+++ b/Former/RowFormers/InlineDatePickerRowFormer.swift
@@ -85,7 +85,7 @@ open class InlineDatePickerRowFormer<T: UITableViewCell>
         }.update()
     }
     
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         former?.deselect(animated: true)
     }
     

--- a/Former/RowFormers/InlinePickerRowFormer.swift
+++ b/Former/RowFormers/InlinePickerRowFormer.swift
@@ -97,7 +97,7 @@ open class InlinePickerRowFormer<T: UITableViewCell, S>
         }.onValueChanged(valueChanged).update()
     }
 
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         former?.deselect(animated: true)
     }
     

--- a/Former/RowFormers/SelectorDatePickerRowFormer.swift
+++ b/Former/RowFormers/SelectorDatePickerRowFormer.swift
@@ -77,7 +77,7 @@ open class SelectorDatePickerRowFormer<T: UITableViewCell>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         former?.deselect(animated: true)
     }
     

--- a/Former/RowFormers/SelectorPickerRowFormer.swift
+++ b/Former/RowFormers/SelectorPickerRowFormer.swift
@@ -97,7 +97,7 @@ open class SelectorPickerRowFormer<T: UITableViewCell, S>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         former?.deselect(animated: true)
     }
     

--- a/Former/RowFormers/SwitchRowFormer.swift
+++ b/Former/RowFormers/SwitchRowFormer.swift
@@ -63,7 +63,7 @@ open class SwitchRowFormer<T: UITableViewCell>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {        
+    open override func cellSelected(indexPath: IndexPath) {        
         former?.deselect(animated: true)
         if switchWhenSelected && enabled {
             let switchButton = cell.formSwitch()

--- a/Former/RowFormers/TextFieldRowFormer.swift
+++ b/Former/RowFormers/TextFieldRowFormer.swift
@@ -82,7 +82,7 @@ open class TextFieldRowFormer<T: UITableViewCell>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {        
+    open override func cellSelected(indexPath: IndexPath) {        
         let textField = cell.formTextField()
         if !textField.isEditing {
             textField.isUserInteractionEnabled = true

--- a/Former/RowFormers/TextViewRowFormer.swift
+++ b/Former/RowFormers/TextViewRowFormer.swift
@@ -108,7 +108,7 @@ open class TextViewRowFormer<T: UITableViewCell>
         }
     }
     
-    public override func cellSelected(indexPath: IndexPath) {
+    open override func cellSelected(indexPath: IndexPath) {
         let textView = cell.formTextView()
         textView.becomeFirstResponder()
         textView.isUserInteractionEnabled = enabled


### PR DESCRIPTION
Makes 'cellSelected' overridable in subclasses.