### PR TITLE
Inline Picker Update

### DIFF
--- a/Former/RowFormers/InlinePickerRowFormer.swift
+++ b/Former/RowFormers/InlinePickerRowFormer.swift
@@ -63,6 +63,11 @@ open class InlinePickerRowFormer<T: UITableViewCell, S>
         if pickerItems.isEmpty {
             displayLabel?.text = ""
         } else {
+            
+//          Sets selected row to 0 to avoid 'index out of range' error. This is in case the updated picker items array count
+//          is less than the prior array count.
+            selectedRow = 0
+            
             displayLabel?.text = pickerItems[selectedRow].title
             _ = pickerItems[selectedRow].displayTitle.map { displayLabel?.attributedText = $0 }
         }

--- a/Former/RowFormers/PickerRowFormer.swift
+++ b/Former/RowFormers/PickerRowFormer.swift
@@ -61,9 +61,15 @@ open class PickerRowFormer<T: UITableViewCell, S>
     
     open override func update() {
         super.update()
-        
         cell.selectionStyle = .none
+        
+        // UPDATES SELECTED ROW TO 0, IN CASE THE COUNT OF UPDATED PICKER ITEMS ARRAY IS LESS THAN PRIOR ARRAY
+        self.selectedRow = 0
+        
+        // RELOADS PICKER VIEW TO UPDATE ITEMS IN INLINE PICKER
         let picker = cell.formPickerView()
+        
+        picker.reloadAllComponents()
         picker.selectRow(selectedRow, inComponent: 0, animated: false)
         picker.isUserInteractionEnabled = enabled
         picker.layer.opacity = enabled ? 1 : 0.5


### PR DESCRIPTION
I've updated the code so that when `pickerItems` array is updated, the user can call `update()` on the cell and it will properly update the picker with the new items. 

I've also have it so it sets the selected picker item index to 0 when the `pickerItems` array is updated in case the updated array contains less items, which results in an 'Index out of range' error. 