### PR TITLE
Two redeclarations have become invalid in the newest Swift and Xcode

### DIFF
--- a/Former/Commons/Former.swift
+++ b/Former/Commons/Former.swift
@@ -86,14 +86,6 @@ public final class Former: NSObject {
         return Array<SectionFormer>(sectionFormers[range])
     }
 
-    public subscript(range: CountableRange<Int>) -> [SectionFormer] {
-        return Array<SectionFormer>(sectionFormers[range])
-    }
-
-    public subscript(range: CountableClosedRange<Int>) -> [SectionFormer] {
-        return Array<SectionFormer>(sectionFormers[range])
-    }
-
     /// To find RowFormer from indexPath.
     public func rowFormer(indexPath: IndexPath) -> RowFormer {
         return self[indexPath.section][indexPath.row]


### PR DESCRIPTION
Two redeclarations have become invalid in the newest Swift and Xcode Beta. 
Because the types do now inherit from Range and ClosedRange so it is not necessary to create an extra subscript for both.

CountableRange inherits from Range 
CountableClosedRange inherits from ClosedRange 
Removing the functions does not do any harm, because they are covered by the two functions above which overwrite the subscript correctly