### PR TITLE
fix InlinePickerRowFormer behavior

### DIFF
--- a/Former/RowFormers/InlinePickerRowFormer.swift
+++ b/Former/RowFormers/InlinePickerRowFormer.swift
@@ -73,10 +73,12 @@ open class InlinePickerRowFormer<T: UITableViewCell, S>
         if pickerItems.isEmpty {
             displayLabel?.text = ""
         } else {
-            
-//          Sets selected row to 0 to avoid 'index out of range' error. This is in case the updated picker items array count
-//          is less than the prior array count.
-            selectedRow = 0
+
+            // Sets selected row to 0 to avoid 'index out of range' error. This is in case the updated picker items array count
+            // is less than the prior array count.
+            if pickerItems.count <= selectedRow {
+                selectedRow = 0
+            }
             
             displayLabel?.text = pickerItems[selectedRow].title
             _ = pickerItems[selectedRow].displayTitle.map { displayLabel?.attributedText = $0 }


### PR DESCRIPTION
To solve https://github.com/ra1028/Former/issues/78, https://github.com/ra1028/Former/issues/81

Maybe, this PR https://github.com/ra1028/Former/pull/64 changed the behavior of InlinePickerRowFormer.

To keep the behavior of before, I beleive this PR will help.