### PR TITLE
Make `init(reuseIdentifier:)` public

### DIFF
--- a/Former/Views/FormHeaderFooterView.swift
+++ b/Former/Views/FormHeaderFooterView.swift
@@ -17,7 +17,7 @@ open class FormHeaderFooterView: UITableViewHeaderFooterView, FormableView {
         setup()
     }
     
-    override init(reuseIdentifier: String?) {
+    override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         setup()
     }


### PR DESCRIPTION
Just like happened with `FormCell`, we should have this public otherwise when you try to create custom ones, you get a crash saying that `init(reuseIdentifier:)` is not implemented.