### PR TITLE
Update podspec

### DIFF
--- a/Former.podspec
+++ b/Former.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.ios.deployment_target = '8.0'
   spec.ios.frameworks = ['UIKit', 'Foundation']
+  spec.swift_version = '4.2'
 end


### PR DESCRIPTION
I fix the issue that it is not possible to build because of the swift version of Former is set to 5 when using Xcode 10 and CocoaPods 1.6.0.