### PR TITLE
Restore `firstResponder` configuration for cells with `UIPickerView`

### DIFF
--- a/Former/Cells/FormSelectorDatePickerCell.swift
+++ b/Former/Cells/FormSelectorDatePickerCell.swift
@@ -15,6 +15,10 @@ open class FormSelectorDatePickerCell: FormCell, SelectorDatePickerFormableRow {
     open var selectorDatePicker: UIDatePicker?
     open var selectorAccessoryView: UIView?
     
+    open override var canBecomeFirstResponder: Bool {
+        return true
+    }
+    
     public private(set) weak var titleLabel: UILabel!
     public private(set) weak var displayLabel: UILabel!
     

--- a/Former/Cells/FormSelectorPickerCell.swift
+++ b/Former/Cells/FormSelectorPickerCell.swift
@@ -15,6 +15,10 @@ open class FormSelectorPickerCell: FormCell, SelectorPickerFormableRow {
     open var selectorPickerView: UIPickerView?
     open var selectorAccessoryView: UIView?
     
+    open override var canBecomeFirstResponder: Bool {
+        return true
+    }
+    
     public private(set) weak var titleLabel: UILabel!
     public private(set) weak var displayLabel: UILabel!
     


### PR DESCRIPTION
fixes #117 